### PR TITLE
use mariadb instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,29 +10,30 @@ Current Version: **17.1.20171115**
 
 You can launch the image using the docker command line,
 
-```bash
-mkdir -p /opt/mysql-egroupware/data
-docker run -d \
---name mysql-egroupware \
--e MYSQL_ROOT_PASSWORD=MySuperSecretSqlPassword \
--e MYSQL_DATABASE=egroupware \
--e MYSQL_USER=egroupware \
--e MYSQL_PASSWORD=AnotherSecretPassword \
--v /opt/mysql-egroupware/data:/var/lib/mysql \
-mysql
+```
+#!/usr/bin/env bash
 
+mkdir -p /opt/egroupware-db/data
+docker run -d \
+ 	--name egroupware-mariadb \
+	 -e MYSQL_ROOT_PASSWORD=MySuperSecretSqlPassword \
+	 -e MYSQL_DATABASE=egroupware \
+	 -e MYSQL_USER=egroupware \
+	 -e MYSQL_PASSWORD=AnotherSecretPassword \
+	 -v /opt/egroupware-db/data:/var/lib/mysql \
+	 mariadb:latest
 
 mkdir -p /opt/egroupware/data
 docker run -d \
---name egroupware \
--e EGROUPWARE_HEADER_ADMIN_USER=admin \
--e EGROUPWARE_HEADER_ADMIN_PASSWORD=123456 \
--e EGROUPWARE_CONFIG_USER=admin \
--e EGROUPWARE_CONFIG_PASSWD=123456 \
--p 10080:80 \
--v /opt/egroupware/data:/var/lib/egroupware \
---link mysql-egroupware:mysql \
-visol/egroupware:14.3.20160428
+  --name egroupware \
+  -e EGROUPWARE_HEADER_ADMIN_USER=admin \
+  -e EGROUPWARE_HEADER_ADMIN_PASSWORD=123456 \
+  -e EGROUPWARE_CONFIG_USER=admin \
+  -e EGROUPWARE_CONFIG_PASSWD=123456 \
+  -p 10080:80 \
+  -v /opt/egroupware/data:/var/lib/egroupware \
+  --link egroupware-mariadb:mysql \
+  visol/egroupware:latest
 ```
 
 Point your browser to `http://localhost:10080/egroupware/setup/` and login with the defined username and password:


### PR DESCRIPTION
There are many reasons why we should use MariaDB; Not just performance.
The "egroupware"-container will use MariaDB by default for all installed tools. Even 'apt install MySQL-Client' will install MariaDB-Client instead and MySQL and MariaDB are not using the same auth mechs any longer. So switch to MariaDB on the DB-Server side will solve that issue.